### PR TITLE
Remove extra blank lines in clone.html

### DIFF
--- a/clone.html
+++ b/clone.html
@@ -172,10 +172,6 @@
 </div>
  
 </div>
-
-
-
-
   <div id="right-content">
     <div id = "volume"><svg class="icon" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="white" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
   <title>Volume</title>


### PR DESCRIPTION
Cleaned up unnecessary blank lines before the right-content div to improve HTML readability.